### PR TITLE
updated github actions workflow to accept 403 as valid status code

### DIFF
--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -20,6 +20,10 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           fail: false
+          args: >
+            --accept 403
+            --user-agent "Mozilla/5.0"
+            
 
       - name: Create Issue From File
         if: steps.lychee.outputs.exit_code != 0


### PR DESCRIPTION
closes #407 