### PR TITLE
Add BrowserBash tutorials to AI learning resources

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1916,6 +1916,7 @@ Access 80M+ residential IPs across 190+ countries with support for HTTP, HTTPS, 
 - [AI Agents for Beginners](https://github.com/microsoft/ai-agents-for-beginners)
 - [LocalAI](https://github.com/mudler/LocalAI)
 - [Promptfoo - Test your prompts, agents, and RAGs. AI Red teaming, pentesting, and vulnerability scanning for LLMs.](https://github.com/promptfoo/promptfoo)
+- [BrowserBash - Learn AI browser testing: 27 tutorials and 500+ articles on running plain-English E2E tests through an AI agent in a real browser (open-source CLI + MCP server).](https://browserbash.com/tutorials)
 - [AI Security Training By ModernSecurity.io - Hands on AI Security course with labs](https://www.modernsecurity.io/courses/ai-security-certification)
 
 </details>


### PR DESCRIPTION
Adds **BrowserBash** to the AI section, beside Promptfoo.

- Tutorials: https://browserbash.com/tutorials (27 tutorials + 500+ articles)
- Repo: https://github.com/PramodDutta/browserbash (open-source, Apache-2.0)

BrowserBash is an open-source CLI + MCP server for AI browser testing: you write plain-English E2E tests and an AI agent runs them in a real browser. The linked tutorials/articles are a free learning resource on AI-driven test automation. Single-line addition, matches the existing bullet format.