### PR TITLE
Add QASkills.sh to QA Assistance tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1799,6 +1799,7 @@ Access 80M+ residential IPs across 190+ countries with support for HTTP, HTTPS, 
 - [Dummy Text Generator](https://www.webtools.services/dummy-text-generator)
 - [Top Ways to Boost Team Morale and Increase Productivity](https://medium.com/@iamfaisalkhatri/top-ways-to-boost-team-morale-and-increase-productivity-626219502e75)
 - [HTTP Cats - A website detailing different status codes](https://http.cat/)
+- [QASkills.sh - Registry of 400+ QA & testing skills installable into Claude Code, Cursor & 30+ AI coding agents](https://qaskills.sh)
 
 </details>
 


### PR DESCRIPTION
Adds [QASkills.sh](https://qaskills.sh) to the **QA Assistance tools** section.

QASkills.sh is an open, MIT-licensed registry of 400+ QA and testing skills (Playwright, API, LLM evaluation, accessibility, performance) that AI coding agents install and follow via the `qaskills` CLI. Useful for testers adopting AI coding agents (Claude Code, Cursor, and 30+ others).

- Site: https://qaskills.sh
- Source: https://github.com/PramodDutta/qaskills

Single-line addition matching the section format.