### PR TITLE
Add GitHub Actions Node 24 migration checklist

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1648,6 +1648,7 @@ Access 80M+ residential IPs across 190+ countries with support for HTTP, HTTPS, 
 
 - [GitHub Actions Documentation](https://docs.github.com/en/actions)
 - [GitHub Actions Guide](https://docs.github.com/en/actions/tutorials)
+- [GitHub Actions Node 24 migration checklist](https://yunczo.github.io/ci-rescue-service/guides/github-actions-node24-migration.html)
 - [Automate your workflow from idea to production](https://github.com/features/actions)
 - [How to setup GitHub Actions for NodeJS project?](https://medium.com/@iamfaisalkhatri/how-to-setup-github-actions-for-node-js-project-1edd6ce1dbe1)
 - [GitHub Actions Tutorial - Basic Concepts and CI/CD Pipeline with Docker](https://www.youtube.com/watch?v=R8_veQiYBjI)


### PR DESCRIPTION
Adds one current resource to **DevOps → GitHub Actions**: a free, source-backed checklist for migrating GitHub Actions workflows to the Node 24 runtime.

The guide covers official-action migration floors, the separate GitHub Enterprise Server artifact path, runner-version requirements, temporary opt-out handling, and manual-review boundaries for pinned, local, third-party, or ambiguous action refs.

Disclosure: I maintain CI Rescue and am submitting this free guide.