### PR TITLE
Add Next.js Security Headers Starter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1211,6 +1211,7 @@ Access 80M+ residential IPs across 190+ countries with support for HTTP, HTTPS, 
 - [Burp Suite Professional video tutorials](https://portswigger.net/burp/pro/video-tutorials)
 - [Burp Suite Tutorial – Getting Started With Burp Suite Tool - Software Testing Help](https://www.softwaretestinghelp.com/burp-suite-tutorial/)
 - [Burp Suite Tutorials - TryHackMe](https://tryhackme.com/module/learn-burp-suite)
+- [Next.js Security Headers Starter](https://github.com/poszothebuilder/nextjs-security-headers-starter) - MIT-licensed baseline with five security headers, a verification script, and a deployment checklist.
 
 </details>
 

--- a/readme.md
+++ b/readme.md
@@ -1961,3 +1961,4 @@ Access 80M+ residential IPs across 190+ countries with support for HTTP, HTTPS, 
 - [ML from Scratch](https://github.com/eriklindernoren/ML-From-Scratch)
 - [ML Algorithms](https://github.com/rushter/MLAlgorithms)
 </details>
+


### PR DESCRIPTION
Adds one focused resource under Security Testing Tools: a free MIT-licensed Next.js baseline with five response headers, a verification script, and a deployment checklist.

Checks:
- No existing Poszo or matching security-headers-starter entry was found.
- The linked repository and documentation are public.
- This changes one README line only.

Disclosure: I am affiliated with Poszo and maintain the submitted resource.